### PR TITLE
Refactor into modules

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,19 @@
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct Background;
+
+pub fn spawn_background(commands: &mut Commands, asset_server: &Res<AssetServer>) {
+    commands.spawn((
+        SpriteBundle {
+            texture: asset_server.load("levels/lab.png"),
+            transform: Transform::from_xyz(0.0, 0.0, -1.0),
+            sprite: Sprite {
+                custom_size: Some(Vec2::new(320.0, 240.0)),
+                ..default()
+            },
+            ..default()
+        },
+        Background,
+    ));
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,14 @@
+pub const WINDOW_WIDTH: f32 = 800.0;
+pub const WINDOW_HEIGHT: f32 = 600.0;
+pub const PLAYER_SPEED: f32 = 100.0;
+pub const JUMP_FORCE: f32 = 300.0;
+pub const GRAVITY: f32 = -800.0;
+pub const SPRITE_SIZE: f32 = 32.0;
+pub const CHEMICAL_PROJECTILE_SPEED: f32 = PLAYER_SPEED * 2.0;
+pub const CHEMICAL_PROJECTILE_SIZE: f32 = 16.0;
+pub const CHEMICAL_PROJECTILE_COOLDOWN: f32 = 0.6;
+pub const CHEMICAL_PROJECTILE_ROTATION_SPEED: f32 = 2.0;
+pub const ENEMY_SPEED: f32 = 60.0;
+pub const ENEMY_SIZE: f32 = 32.0;
+pub const WAVE_AMPLITUDE: f32 = 50.0;
+pub const WAVE_FREQUENCY: f32 = 2.0;

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -1,0 +1,56 @@
+use bevy::prelude::*;
+use crate::constants::{WINDOW_WIDTH, ENEMY_SIZE, ENEMY_SPEED, WAVE_AMPLITUDE, WAVE_FREQUENCY};
+use crate::movement::Velocity;
+
+#[derive(Component)]
+pub struct Enemy {
+    pub start_y: f32,
+    pub time: f32,
+    pub moving_right: bool,
+}
+
+pub fn spawn_enemy(commands: &mut Commands, asset_server: &Res<AssetServer>) {
+    commands.spawn((
+        SpriteBundle {
+            texture: asset_server.load("alien.png"),
+            transform: Transform::from_xyz(-WINDOW_WIDTH / 2.0, 0.0, 0.0),
+            sprite: Sprite {
+                custom_size: Some(Vec2::new(ENEMY_SIZE / 2.0, ENEMY_SIZE)),
+                ..default()
+            },
+            ..default()
+        },
+        Enemy {
+            start_y: 0.0,
+            time: 0.0,
+            moving_right: true,
+        },
+        Velocity { speed: Vec2::ZERO },
+    ));
+}
+
+pub fn enemy_movement(
+    time: Res<Time>,
+    mut query: Query<(&mut Transform, &mut Enemy)>,
+) {
+    for (mut transform, mut enemy) in query.iter_mut() {
+        enemy.time += time.delta_seconds();
+
+        let y_offset = (enemy.time * WAVE_FREQUENCY).sin() * WAVE_AMPLITUDE;
+        transform.translation.y = enemy.start_y + y_offset;
+
+        if enemy.moving_right {
+            transform.translation.x += ENEMY_SPEED * time.delta_seconds();
+            if transform.translation.x > WINDOW_WIDTH / 2.0 - ENEMY_SIZE {
+                enemy.moving_right = false;
+                transform.scale.x = -1.0;
+            }
+        } else {
+            transform.translation.x -= ENEMY_SPEED * time.delta_seconds();
+            if transform.translation.x < -WINDOW_WIDTH / 2.0 + ENEMY_SIZE {
+                enemy.moving_right = true;
+                transform.scale.x = 1.0;
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,59 +1,33 @@
 use bevy::prelude::*;
 use bevy_pixel_camera::{PixelCameraPlugin, PixelZoom};
 
-const WINDOW_WIDTH: f32 = 800.0;
-const WINDOW_HEIGHT: f32 = 600.0;
-const PLAYER_SPEED: f32 = 100.0;
-const JUMP_FORCE: f32 = 300.0;
-const GRAVITY: f32 = -800.0;
-const SPRITE_SIZE: f32 = 32.0;
-const CHEMICAL_PROJECTILE_SPEED: f32 = PLAYER_SPEED * 2.0;
-const CHEMICAL_PROJECTILE_SIZE: f32 = 16.0;
-const CHEMICAL_PROJECTILE_COOLDOWN: f32 = 0.6;
-const CHEMICAL_PROJECTILE_ROTATION_SPEED: f32 = 2.0; // Radians per second
-const ENEMY_SPEED: f32 = 60.0;
-const ENEMY_SIZE: f32 = 32.0;
-const WAVE_AMPLITUDE: f32 = 50.0;
-const WAVE_FREQUENCY: f32 = 2.0;
+mod constants;
+mod movement;
+mod player;
+mod projectile;
+mod enemy;
+mod background;
 
-#[derive(Component)]
-struct Player {
-    is_jumping: bool,
-    facing_right: bool,
-    last_shot_time: f32,
-}
-
-#[derive(Component)]
-struct Velocity {
-    speed: Vec2,
-}
-
-#[derive(Component)]
-struct ChemicalProjectile;
-
-#[derive(Component)]
-struct Background;
-
-#[derive(Component)]
-struct Enemy {
-    start_y: f32,
-    time: f32,
-    moving_right: bool,
-}
+use constants::*;
+use movement::apply_velocity;
+use player::{apply_gravity, player_movement, shoot_chemical, spawn_player};
+use projectile::{cleanup_projectiles, rotate_projectiles};
+use enemy::{enemy_movement, spawn_enemy};
+use background::spawn_background;
 
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(
-                ImagePlugin::default_nearest() // Use nearest-neighbor filtering for crisp pixel art
-            ).set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "Scienteer".into(),
-                    resolution: (WINDOW_WIDTH, WINDOW_HEIGHT).into(),
+            DefaultPlugins
+                .set(ImagePlugin::default_nearest())
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "Scienteer".into(),
+                        resolution: (WINDOW_WIDTH, WINDOW_HEIGHT).into(),
+                        ..default()
+                    }),
                     ..default()
                 }),
-                ..default()
-            }),
             PixelCameraPlugin,
         ))
         .add_systems(Startup, setup)
@@ -67,214 +41,19 @@ fn main() {
                 cleanup_projectiles,
                 rotate_projectiles,
                 enemy_movement,
-            ).chain(),
+            )
+                .chain(),
         )
         .run();
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Camera
     commands.spawn((
         Camera2dBundle::default(),
         PixelZoom::FitSize { width: 320, height: 240 },
     ));
 
-    // Background
-    commands.spawn((
-        SpriteBundle {
-            texture: asset_server.load("levels/lab.png"),
-            transform: Transform::from_xyz(0.0, 0.0, -1.0),  // Place behind other elements
-            sprite: Sprite {
-                custom_size: Some(Vec2::new(320.0, 240.0)),  // Match the PixelZoom dimensions
-                ..default()
-            },
-            ..default()
-        },
-        Background,
-    ));
-
-    // Player with sprite
-    commands.spawn((
-        SpriteBundle {
-            texture: asset_server.load("scientist.png"),
-            transform: Transform::from_xyz(0.0, -90.0, 0.0),  // Position at 25% from bottom of screen (240 * 0.25 - 240/2 = -90)
-            sprite: Sprite {
-                custom_size: Some(Vec2::new(SPRITE_SIZE, SPRITE_SIZE)),
-                ..default()
-            },
-            ..default()
-        },
-        Player {
-            is_jumping: false,
-            facing_right: true,
-            last_shot_time: 0.0,
-        },
-        Velocity { speed: Vec2::ZERO },
-    ));
-
-    // Enemy
-    commands.spawn((
-        SpriteBundle {
-            texture: asset_server.load("alien.png"),
-            transform: Transform::from_xyz(-WINDOW_WIDTH / 2.0, 0.0, 0.0),
-            sprite: Sprite {
-                custom_size: Some(Vec2::new(ENEMY_SIZE / 2.0, ENEMY_SIZE)),
-                ..default()
-            },
-            ..default()
-        },
-        Enemy {
-            start_y: 0.0,
-            time: 0.0,
-            moving_right: true,
-        },
-        Velocity { speed: Vec2::ZERO },
-    ));
-}
-
-fn player_movement(
-    keyboard: Res<Input<KeyCode>>,
-    mut query: Query<(&mut Velocity, &mut Player, &Transform, &mut Sprite)>,
-) {
-    let (mut velocity, mut player, _transform, mut sprite) = query.single_mut();
-
-    // Horizontal movement
-    let mut direction = 0.0;
-    if keyboard.pressed(KeyCode::A) || keyboard.pressed(KeyCode::Left) {
-        direction -= 1.0;
-        player.facing_right = false;
-        sprite.flip_x = true;
-    }
-    if keyboard.pressed(KeyCode::D) || keyboard.pressed(KeyCode::Right) {
-        direction += 1.0;
-        player.facing_right = true;
-        sprite.flip_x = false;
-    }
-
-    // Jumping
-    if (keyboard.just_pressed(KeyCode::Space) || keyboard.just_pressed(KeyCode::Up)) && !player.is_jumping {
-        velocity.speed.y = JUMP_FORCE;
-        player.is_jumping = true;
-    }
-
-    // Apply horizontal movement
-    velocity.speed.x = direction * PLAYER_SPEED;
-}
-
-fn apply_gravity(
-    mut query: Query<(&mut Velocity, &mut Player, &Transform)>,
-    time: Res<Time>,
-) {
-    let (mut velocity, mut player, transform) = query.single_mut();
-    
-    // Apply gravity
-    velocity.speed.y += GRAVITY * time.delta_seconds();
-
-    // Check if landed (accounting for sprite size)
-    if transform.translation.y <= -90.0 && velocity.speed.y <= 0.0 {
-        velocity.speed.y = 0.0;
-        player.is_jumping = false;
-    }
-}
-
-fn apply_velocity(mut query: Query<(&Velocity, &mut Transform)>, time: Res<Time>) {
-    for (velocity, mut transform) in query.iter_mut() {
-        let delta = time.delta_seconds();
-        
-        // Apply movement with delta time
-        transform.translation.x += velocity.speed.x * delta;
-        transform.translation.y += velocity.speed.y * delta;
-        
-        // Keep player above ground level
-        if transform.translation.y < -90.0 {
-            transform.translation.y = -90.0;
-        }
-    }
-}
-
-fn shoot_chemical(
-    mut commands: Commands,
-    keyboard: Res<Input<KeyCode>>,
-    time: Res<Time>,
-    asset_server: Res<AssetServer>,
-    mut query: Query<(&mut Player, &Transform)>,
-) {
-    let (mut player, transform) = query.single_mut();
-    
-    if (keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight)) 
-        && time.elapsed_seconds() >= player.last_shot_time + CHEMICAL_PROJECTILE_COOLDOWN {
-        let direction = if player.facing_right { 1.0 } else { -1.0 };
-        
-        commands.spawn((
-            SpriteBundle {
-                texture: asset_server.load("bottle.png"),
-                sprite: Sprite {
-                    custom_size: Some(Vec2::new(CHEMICAL_PROJECTILE_SIZE, CHEMICAL_PROJECTILE_SIZE)),
-                    flip_x: !player.facing_right,
-                    ..default()
-                },
-                transform: Transform::from_xyz(
-                    transform.translation.x,
-                    transform.translation.y,
-                    0.0,
-                ),
-                ..default()
-            },
-            ChemicalProjectile,
-            Velocity {
-                speed: Vec2::new(CHEMICAL_PROJECTILE_SPEED * direction, 0.0),
-            },
-        ));
-        
-        player.last_shot_time = time.elapsed_seconds();
-    }
-}
-
-fn cleanup_projectiles(
-    mut commands: Commands,
-    query: Query<(Entity, &Transform), With<ChemicalProjectile>>,
-) {
-    for (entity, transform) in query.iter() {
-        if transform.translation.x < -WINDOW_WIDTH / 2.0 
-            || transform.translation.x > WINDOW_WIDTH / 2.0 {
-            commands.entity(entity).despawn();
-        }
-    }
-}
-
-fn rotate_projectiles(
-    time: Res<Time>,
-    mut query: Query<&mut Transform, With<ChemicalProjectile>>,
-) {
-    for mut transform in query.iter_mut() {
-        transform.rotate_z(CHEMICAL_PROJECTILE_ROTATION_SPEED * time.delta_seconds());
-    }
-}
-
-fn enemy_movement(
-    time: Res<Time>,
-    mut query: Query<(&mut Transform, &mut Enemy)>,
-) {
-    for (mut transform, mut enemy) in query.iter_mut() {
-        enemy.time += time.delta_seconds();
-        
-        // Calculate vertical position using a sine wave
-        let y_offset = (enemy.time * WAVE_FREQUENCY).sin() * WAVE_AMPLITUDE;
-        transform.translation.y = enemy.start_y + y_offset;
-        
-        // Move horizontally
-        if enemy.moving_right {
-            transform.translation.x += ENEMY_SPEED * time.delta_seconds();
-            if transform.translation.x > WINDOW_WIDTH / 2.0 - ENEMY_SIZE {
-                enemy.moving_right = false;
-                transform.scale.x = -1.0; // Flip sprite to face left
-            }
-        } else {
-            transform.translation.x -= ENEMY_SPEED * time.delta_seconds();
-            if transform.translation.x < -WINDOW_WIDTH / 2.0 + ENEMY_SIZE {
-                enemy.moving_right = true;
-                transform.scale.x = 1.0; // Reset sprite to face right
-            }
-        }
-    }
+    spawn_background(&mut commands, &asset_server);
+    spawn_player(&mut commands, &asset_server);
+    spawn_enemy(&mut commands, &asset_server);
 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -1,0 +1,17 @@
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct Velocity {
+    pub speed: Vec2,
+}
+
+pub fn apply_velocity(mut query: Query<(&Velocity, &mut Transform)>, time: Res<Time>) {
+    for (velocity, mut transform) in query.iter_mut() {
+        let delta = time.delta_seconds();
+        transform.translation.x += velocity.speed.x * delta;
+        transform.translation.y += velocity.speed.y * delta;
+        if transform.translation.y < -90.0 {
+            transform.translation.y = -90.0;
+        }
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,110 @@
+use bevy::prelude::*;
+use crate::constants::{PLAYER_SPEED, JUMP_FORCE, GRAVITY, SPRITE_SIZE, CHEMICAL_PROJECTILE_SPEED, CHEMICAL_PROJECTILE_SIZE, CHEMICAL_PROJECTILE_COOLDOWN};
+use crate::movement::Velocity;
+use crate::projectile::ChemicalProjectile;
+
+#[derive(Component)]
+pub struct Player {
+    pub is_jumping: bool,
+    pub facing_right: bool,
+    pub last_shot_time: f32,
+}
+
+pub fn spawn_player(commands: &mut Commands, asset_server: &Res<AssetServer>) {
+    commands.spawn((
+        SpriteBundle {
+            texture: asset_server.load("scientist.png"),
+            transform: Transform::from_xyz(0.0, -90.0, 0.0),
+            sprite: Sprite {
+                custom_size: Some(Vec2::new(SPRITE_SIZE, SPRITE_SIZE)),
+                ..default()
+            },
+            ..default()
+        },
+        Player {
+            is_jumping: false,
+            facing_right: true,
+            last_shot_time: 0.0,
+        },
+        Velocity { speed: Vec2::ZERO },
+    ));
+}
+
+pub fn player_movement(
+    keyboard: Res<Input<KeyCode>>,
+    mut query: Query<(&mut Velocity, &mut Player, &Transform, &mut Sprite)>,
+) {
+    let (mut velocity, mut player, _transform, mut sprite) = query.single_mut();
+
+    let mut direction = 0.0;
+    if keyboard.pressed(KeyCode::A) || keyboard.pressed(KeyCode::Left) {
+        direction -= 1.0;
+        player.facing_right = false;
+        sprite.flip_x = true;
+    }
+    if keyboard.pressed(KeyCode::D) || keyboard.pressed(KeyCode::Right) {
+        direction += 1.0;
+        player.facing_right = true;
+        sprite.flip_x = false;
+    }
+
+    if (keyboard.just_pressed(KeyCode::Space) || keyboard.just_pressed(KeyCode::Up)) && !player.is_jumping {
+        velocity.speed.y = JUMP_FORCE;
+        player.is_jumping = true;
+    }
+
+    velocity.speed.x = direction * PLAYER_SPEED;
+}
+
+pub fn apply_gravity(
+    mut query: Query<(&mut Velocity, &mut Player, &Transform)>,
+    time: Res<Time>,
+) {
+    let (mut velocity, mut player, transform) = query.single_mut();
+
+    velocity.speed.y += GRAVITY * time.delta_seconds();
+
+    if transform.translation.y <= -90.0 && velocity.speed.y <= 0.0 {
+        velocity.speed.y = 0.0;
+        player.is_jumping = false;
+    }
+}
+
+pub fn shoot_chemical(
+    mut commands: Commands,
+    keyboard: Res<Input<KeyCode>>,
+    time: Res<Time>,
+    asset_server: Res<AssetServer>,
+    mut query: Query<(&mut Player, &Transform)>,
+) {
+    let (mut player, transform) = query.single_mut();
+
+    if (keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight))
+        && time.elapsed_seconds() >= player.last_shot_time + CHEMICAL_PROJECTILE_COOLDOWN
+    {
+        let direction = if player.facing_right { 1.0 } else { -1.0 };
+
+        commands.spawn((
+            SpriteBundle {
+                texture: asset_server.load("bottle.png"),
+                sprite: Sprite {
+                    custom_size: Some(Vec2::new(CHEMICAL_PROJECTILE_SIZE, CHEMICAL_PROJECTILE_SIZE)),
+                    flip_x: !player.facing_right,
+                    ..default()
+                },
+                transform: Transform::from_xyz(
+                    transform.translation.x,
+                    transform.translation.y,
+                    0.0,
+                ),
+                ..default()
+            },
+            ChemicalProjectile,
+            Velocity {
+                speed: Vec2::new(CHEMICAL_PROJECTILE_SPEED * direction, 0.0),
+            },
+        ));
+
+        player.last_shot_time = time.elapsed_seconds();
+    }
+}

--- a/src/projectile.rs
+++ b/src/projectile.rs
@@ -1,0 +1,27 @@
+use bevy::prelude::*;
+use crate::constants::{WINDOW_WIDTH, CHEMICAL_PROJECTILE_ROTATION_SPEED};
+
+#[derive(Component)]
+pub struct ChemicalProjectile;
+
+pub fn cleanup_projectiles(
+    mut commands: Commands,
+    query: Query<(Entity, &Transform), With<ChemicalProjectile>>,
+) {
+    for (entity, transform) in query.iter() {
+        if transform.translation.x < -WINDOW_WIDTH / 2.0
+            || transform.translation.x > WINDOW_WIDTH / 2.0
+        {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+pub fn rotate_projectiles(
+    time: Res<Time>,
+    mut query: Query<&mut Transform, With<ChemicalProjectile>>,
+) {
+    for mut transform in query.iter_mut() {
+        transform.rotate_z(CHEMICAL_PROJECTILE_ROTATION_SPEED * time.delta_seconds());
+    }
+}


### PR DESCRIPTION
## Summary
- split main file into modules
- organize components and systems into `player`, `enemy`, `projectile`, `background`, `movement`, and `constants`

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6842e4a57da08322a8a09d5c8d0119f1